### PR TITLE
Two new convenience scripts

### DIFF
--- a/crawler/errorcodes.py
+++ b/crawler/errorcodes.py
@@ -33,21 +33,21 @@ def json_load_byteified(file_handle):
 	'''
 	Crawler output is unicode. Change to UTF-8 for better handling
 	'''
+	def _byteify(data, ignore_dicts = False):
+		if isinstance(data, unicode):
+			return data.encode('utf-8')
+		if isinstance(data, list):
+			return [ _byteify(item, ignore_dicts=True) for item in data ]
+		if isinstance(data, dict) and not ignore_dicts:
+			return {
+				_byteify(key, ignore_dicts=True): _byteify(value, ignore_dicts=True)
+				for key, value in data.iteritems()
+				}
+		return data
 	return _byteify(
 		json.load(file_handle, object_hook=_byteify),
 		ignore_dicts=True
 	)
-def _byteify(data, ignore_dicts = False):
-	if isinstance(data, unicode):
-		return data.encode('utf-8')
-	if isinstance(data, list):
-		return [ _byteify(item, ignore_dicts=True) for item in data ]
-	if isinstance(data, dict) and not ignore_dicts:
-		return {
-			_byteify(key, ignore_dicts=True): _byteify(value, ignore_dicts=True)
-			for key, value in data.iteritems()
-			}
-	return data
 
 def identifyEnergyRange(filenamedir):
 	'''
@@ -153,8 +153,6 @@ def ana(filename):
 			with open(outstring,'w') as thefile:
 				for item in dicEnergy[key]:
 					thefile.write("%s\n" % item)
-	
-	
 	
 
 if __name__ == '__main__':

--- a/crawler/errorcodes.py
+++ b/crawler/errorcodes.py
@@ -139,7 +139,7 @@ def ana(filename):
 				
 				if iteration['emax'] > 1e+6: key2 = str(iteration['emax']/1e+6)+'TeV'
 				elif iteration['emax'] > 1e+3: key2 = str(iteration['emax']/1e+3)+'GeV'
-				else: key1 = str(iteration['emax'])+'MeV'
+				else: key2 = str(iteration['emax'])+'MeV'
 				
 				key = key1 + '_' + key2
 				try: 

--- a/crawler/resumeCrawler.py
+++ b/crawler/resumeCrawler.py
@@ -1,0 +1,74 @@
+'''
+
+resumeCrawler
+
+Use this when an instance of crawl_filelist.sh is killed before it finishes.
+Script sets up a new working dir in ./p2/ with the remaining part to be crawled
+
+Dirty workaround to allow the crawler to skip files that were already crawled 
+
+Usage:
+	> python resumeCrawler.py listOfFiles.txt crawlerOutput.json
+	
+
+'''
+
+from __future__ import absolute_import, print_function
+
+import json
+import os
+import sys
+from glob import glob
+from shutil import copy
+
+from errorcodes import json_load_byteified
+
+
+def run(task,crawled):
+	
+	if os.path.isdir('p2'):
+		print("Detected a task for crawler part2")
+		return
+	
+	files = []
+	with open(task,'r') as f:
+		for lines in f:
+			files.append(lines.replace('\n',''))
+			
+	with open(crawled,'r') as f:	
+		diclist = json_load_byteified(f)
+		
+	if len(files) == len(diclist):
+		print("Crawler done, nothing to resume")
+		return
+	
+	filesCrawled = []
+	filesToCrawl = []
+	
+	for iteration in diclist:
+		filesCrawled.append(iteration['lfn'])
+	for f in files:
+		if f not in filesCrawled:
+			filesToCrawl.append(f)
+	
+	print("Found ", len(filesToCrawl), " files to be crawled")
+			
+	os.mkdir('p2')
+	newName = task.replace('.txt','.part2.txt')
+	with open('p2/'+newName,'w') as f:
+		for item in filesToCrawl:
+			f.write(item+'\n')
+	
+	bashScripts = glob('*.sh')
+	for x in bashScripts: copy(x,'./p2/')
+	
+	with open('p2/badFiles.bad','w') as f:
+		os.utime('p2/badFiles.bad',None)
+	
+	
+if __name__ == '__main__':
+	
+	task = sys.argv[1]
+	crawled = sys.argv[2]
+	
+	run(task,crawled)

--- a/mc_reprocess/check_completion.py
+++ b/mc_reprocess/check_completion.py
@@ -1,0 +1,44 @@
+'''
+
+Check completion: prints to std:out the number of files to be processed, and the number of files already processed
+
+Usage:
+	> python check_completion.py /path/to/task /path/to/output release_tag
+	
+Example:
+	Running:
+		> python check_completion.py /dampe/data3/users/public/crawler/txt/v6/allProton-v5r4p2_1GeV_15GeV.txt /dampe/data3/XROOTD_DIR/MC/reco/v6r0p0/ v6r0p0
+	Output:
+		allProton-v5r4p2_1GeV_15GeV : 325/1485
+
+'''
+
+from __future__ import print_function, absolute_import
+
+import os
+import sys
+from submit import mc2reco
+
+if __name__ == '__main__':
+	
+	n_done = 0
+	
+	files = []
+	
+	with open(sys.argv[1],'r') as f:
+		for line in f:
+			files.append(line.replace('\n',''))
+	outputDir = sys.argv[2]
+	tag = sys.argv[3]
+	
+	n_total = len(files)
+	
+	for f in files:
+		if os.path.isfile(mc2reco(f,version=tag,newpath=outputDir)):
+			n_done += 1
+			
+	taskName = os.path.basename(sys.argv[1]).replace('.txt','')
+	
+	print(taskName,' : ',n_done,'/',n_total)
+	
+	

--- a/mc_reprocess/submit.py
+++ b/mc_reprocess/submit.py
@@ -54,78 +54,80 @@ def make_wrapper(infile,outfile):
     of.write("".join(lines_out))
     of.close()
 
-cfg = yload(open(argv[1],"rb"))
-
-time_per_job = cfg.get("time_per_job",3600.)
-if ":" in str(time_per_job):
-    now = datetime(day=1,month=1,year=1900,hour=0,minute=0,second=0)
-    dt  = datetime.strptime(str(time_per_job),"%H:%M:%S")
-    time_per_job = str(dt-now)
-else:
-    time_per_job = str(timedelta(seconds=time_per_job))
-
-environ["STIME"]=time_per_job
-environ["SMEM"] =cfg.get("mem_per_job","2G")
-environ["SWPATH"]=cfg.get("DMPSWSYS","/cvmfs/dampe.cern.ch/rhel6-64/opt/releases/trunk")
-g_maxfiles = int(cfg.get("files_per_job",10))
-
-ncycles = 1
-
-version=cfg.get("tag","trunk")
-
-slurm_exec_dir=dirname(abspath(__file__))
-environ["SLURM_EXEC_DIR"]=slurm_exec_dir
-environ["DLOG"]=cfg.get("log_level","INFO")
-wrapper=opjoin(slurm_exec_dir,"submit_slurm.sh")
-
-environ["SCRATCH"]=cfg.get("scratch_dir","${HOME}/scratch")
-
-### LOOP OVER CYCLES ####
-for i in xrange(ncycles):
-    print '++++ CYCLE %i ++++'%i
-    txtfiles = []
-    for _d in cfg['inputloc']:
-        txtfiles+=glob(_d)
-
-    files_to_process = []
-    for t in txtfiles:
-        print 'reading %s...'%t
-        files_to_process+=[f.replace("\n","") for f in open(t,"r").readlines()]
-        print 'size: ',len(files_to_process)
-    wd=opjoin(cfg['workdir'],cfg['tag'])
-    wd=opjoin(wd,"cycle_%i"%(i+1))
-    environ["WORKDIR"]=abspath(wd)
-    mkdir(wd)
-    print '%i: found %i files to process this cycle.'%(i+1, len(files_to_process))
-    print 'check if files exist already'
-
-    reco_file = lambda f : mc2reco(f,version=version,newpath=cfg['outputdir'])
-    #files_to_process = tqdm([f for f in files_to_process if not isfile(reco_file(f))])
-    _files_to_process = []
-    for f in tqdm(files_to_process):
-        if not isfile(reco_file(f)): _files_to_process.append(f)
-    files_to_process = _files_to_process
-    print 'after check: found %i files to process this cycle.'%len(files_to_process)
-    nfiles = len(files_to_process)
-    chunks = [files_to_process[x:x+g_maxfiles] for x in xrange(0, len(files_to_process), g_maxfiles)]
-    print 'created %i chunks this cycle'%len(chunks)
-    for j,ch in enumerate(chunks):
-        print '** working on chunk %i, size: %i **'%(j+1,len(ch))
-        ofile = opjoin(wd,"chunk_%i.yaml"%(j+1))
-        inf_c = ch
-        out_c = [reco_file(f) for f in inf_c]
-        ydump(dict(zip(inf_c,out_c)),open(ofile,'wb'))
-        assert isfile(ofile), "yaml file missing!"
-        print 'size of chunk: ',len(out_c)
-    max_jobs = int(cfg.get("max_jobs",10))
-    nch = len(chunks)
-    sarr = "1-{nchunks}%{jobs}".format(nchunks=nch,jobs=max_jobs) if \
-            nch > max_jobs else "1-{nchunks}".format(nchunks=nch)
-    environ["SARR"]=sarr
-
-    #print '*** ENV DUMP ***'
-    #system("env | sort")
-    new_wrapper = opjoin(wd,"submit_slurm.sh")
-    make_wrapper(wrapper,new_wrapper)
-    system("sbatch {wrapper}".format(wrapper=new_wrapper))
+if __name__ == '__main__':
+	
+	cfg = yload(open(argv[1],"rb"))
+	
+	time_per_job = cfg.get("time_per_job",3600.)
+	if ":" in str(time_per_job):
+	    now = datetime(day=1,month=1,year=1900,hour=0,minute=0,second=0)
+	    dt  = datetime.strptime(str(time_per_job),"%H:%M:%S")
+	    time_per_job = str(dt-now)
+	else:
+	    time_per_job = str(timedelta(seconds=time_per_job))
+	
+	environ["STIME"]=time_per_job
+	environ["SMEM"] =cfg.get("mem_per_job","2G")
+	environ["SWPATH"]=cfg.get("DMPSWSYS","/cvmfs/dampe.cern.ch/rhel6-64/opt/releases/trunk")
+	g_maxfiles = int(cfg.get("files_per_job",10))
+	
+	ncycles = 1
+	
+	version=cfg.get("tag","trunk")
+	
+	slurm_exec_dir=dirname(abspath(__file__))
+	environ["SLURM_EXEC_DIR"]=slurm_exec_dir
+	environ["DLOG"]=cfg.get("log_level","INFO")
+	wrapper=opjoin(slurm_exec_dir,"submit_slurm.sh")
+	
+	environ["SCRATCH"]=cfg.get("scratch_dir","${HOME}/scratch")
+	
+	### LOOP OVER CYCLES ####
+	for i in xrange(ncycles):
+	    print '++++ CYCLE %i ++++'%i
+	    txtfiles = []
+	    for _d in cfg['inputloc']:
+	        txtfiles+=glob(_d)
+	
+	    files_to_process = []
+	    for t in txtfiles:
+	        print 'reading %s...'%t
+	        files_to_process+=[f.replace("\n","") for f in open(t,"r").readlines()]
+	        print 'size: ',len(files_to_process)
+	    wd=opjoin(cfg['workdir'],cfg['tag'])
+	    wd=opjoin(wd,"cycle_%i"%(i+1))
+	    environ["WORKDIR"]=abspath(wd)
+	    mkdir(wd)
+	    print '%i: found %i files to process this cycle.'%(i+1, len(files_to_process))
+	    print 'check if files exist already'
+	
+	    reco_file = lambda f : mc2reco(f,version=version,newpath=cfg['outputdir'])
+	    #files_to_process = tqdm([f for f in files_to_process if not isfile(reco_file(f))])
+	    _files_to_process = []
+	    for f in tqdm(files_to_process):
+	        if not isfile(reco_file(f)): _files_to_process.append(f)
+	    files_to_process = _files_to_process
+	    print 'after check: found %i files to process this cycle.'%len(files_to_process)
+	    nfiles = len(files_to_process)
+	    chunks = [files_to_process[x:x+g_maxfiles] for x in xrange(0, len(files_to_process), g_maxfiles)]
+	    print 'created %i chunks this cycle'%len(chunks)
+	    for j,ch in enumerate(chunks):
+	        print '** working on chunk %i, size: %i **'%(j+1,len(ch))
+	        ofile = opjoin(wd,"chunk_%i.yaml"%(j+1))
+	        inf_c = ch
+	        out_c = [reco_file(f) for f in inf_c]
+	        ydump(dict(zip(inf_c,out_c)),open(ofile,'wb'))
+	        assert isfile(ofile), "yaml file missing!"
+	        print 'size of chunk: ',len(out_c)
+	    max_jobs = int(cfg.get("max_jobs",10))
+	    nch = len(chunks)
+	    sarr = "1-{nchunks}%{jobs}".format(nchunks=nch,jobs=max_jobs) if \
+	            nch > max_jobs else "1-{nchunks}".format(nchunks=nch)
+	    environ["SARR"]=sarr
+	
+	    #print '*** ENV DUMP ***'
+	    #system("env | sort")
+	    new_wrapper = opjoin(wd,"submit_slurm.sh")
+	    make_wrapper(wrapper,new_wrapper)
+	    system("sbatch {wrapper}".format(wrapper=new_wrapper))
 #### DONE


### PR DESCRIPTION
* crawler/resumeCrawler.py

In its current state the crawler does not know whether a file has been crawled or not. This script builds a filelist of files that have not been crawled. Useful if an instance of crawl_filelist.sh gets killed before completion. Very dirty workaround

* mc_reprocess/check_completion.py

Checks the status of a given MC reconstruction task, i.e. total number of reco files and total number of simu files. Useful monitor.
Had to modify the submit.py to protect the code behind a "main" statement, to allow import of the very useful mc2reco() function.